### PR TITLE
Add dev container configuration with Elixir image

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,15 @@
+{
+  "name": "Rodar Lua",
+  "image": "hexpm/elixir:1.18.3-erlang-27.3.3-ubuntu-noble-20250127",
+  "features": {
+    "ghcr.io/devcontainers/features/git:1": {}
+  },
+  "postCreateCommand": "mix local.hex --force && mix local.rebar --force && mix deps.get",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "JakeBecker.elixir-ls"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Sets up a dev container using the official hexpm/elixir image (1.18.3 / OTP 27)
on Ubuntu Noble. Automatically installs hex, rebar, and project dependencies.

https://claude.ai/code/session_01PfTMm4doBRN7CdAPfxAgJv